### PR TITLE
feat: support absolute routes_dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage.html
 *.log
 yarn.lock
 package-lock.json
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ coverage.html
 *.log
 yarn.lock
 package-lock.json
-/.idea/

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ exports.plugin = {
         let routes = AutoRoute.getRoutes(files);
 
         if (opts.use_prefix) {
-            prefixes = AutoRoute.getPrefixes(files, Path.join(process.cwd(), opts.routes_dir));
+            prefixes = AutoRoute.getPrefixes(files, Path.resolve(opts.routes_dir));
             routes = AutoRoute.updatePaths(prefixes, routes, server.settings.router.stripTrailingSlash);
         }
 

--- a/lib/auto-route.js
+++ b/lib/auto-route.js
@@ -18,7 +18,7 @@ module.exports.getRoutes = (files) => {
 
     return files.map((file) => {
 
-        return Hoek.clone(require(Path.join(process.cwd(), file)));
+        return Hoek.clone(require(Path.resolve(file)));
     });
 };
 


### PR DESCRIPTION
say, all route files are in `root/src/routes` and the start script is in `root/src/boot`, so you can use 

```
// routes_dir: path.resolve(__dirname, "../routes"),
// routes_dir: path.join(__dirname, "../routes"),
// routes_dir: "src/routes",
```